### PR TITLE
Wiki language update

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -38,11 +38,6 @@ module.exports = {
             name: "Serving for .. members in total",
             value: bot.totalMembers(),
             inline: true
-          },
-          {
-            name: "Version",
-            value: config.VERSION,
-            inline: false
           }
         ],
         timestamp: new Date()

--- a/commands/sources.js
+++ b/commands/sources.js
@@ -9,8 +9,11 @@ const requests = require('./../modules/requests')
  * */
 module.exports = {
   name: 'sources',
+  alias: ['references'],
   description: 'Sends you a full list of all sources of a Wikipedia article',
   execute(message, args, config){
+
+    const command = args[0].slice(config.PREFIX.length)
     // Log the command
     // Check in what type of channel the command was executed
     if(message.channel.type === "dm" || message.channel.type === "group"){
@@ -31,23 +34,23 @@ module.exports = {
             icon_url: 'https://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png',
             name: 'Wikipedia'
           },
-          title: `Sources Command 101`,
+          title: `'References' Command 101`,
           timestamp: new Date(),
           description: "This helps to understand how this command works.",
           fields: [
             {
               name: "Generally the command works like this:",
-              value: '`' + config.PREFIX + this.name + ' "<search argument>" <range>` \n\n' +
-                '**Example:** ' + '`' + config.PREFIX + this.name + ' "Elon Musk" 1-5`\n ' +
+              value: '`' + config.PREFIX + command + ' "<search argument>" <range>` \n\n' +
+                '**Example:** ' + '`' + config.PREFIX + command + ' "Elon Musk" 1-5`\n ' +
                 'You give a search term and a specific range from which \nto which reference you want to get the link of.'
             },
             {
               name: "\nYou can also get some information about the references\nof a Wikipedia article with setting range to *info*",
-              value: '**Example:** ' + '`' + config.PREFIX + this.name + ' "Elon Musk" info`\n '
+              value: '**Example:** ' + '`' + config.PREFIX + command + ' "Elon Musk" info`\n '
             },
             {
               name: "\nIf you leave the range empty or write *all* as the range, \nyou'll get the link to the Wikipedia article references",
-              value: '**Example:** ' + '`' + config.PREFIX + this.name + ' "Elon Musk" all`\n '
+              value: '**Example:** ' + '`' + config.PREFIX + command + ' "Elon Musk" all`\n '
             }
           ]
         }
@@ -55,7 +58,7 @@ module.exports = {
 
     }else {
       // Get the command arguments
-      let commandArgs = message.content.replace(`${config.PREFIX}${this.name} `, "")
+      let commandArgs = message.content.replace(`${config.PREFIX}${command} `, "")
       // https://regex101.com/r/qa3KxQ/1/ and https://stackoverflow.com/questions/2817646/javascript-split-string-on-space-or-on-quotes-to-array
       commandArgs = commandArgs.match(/[^\s"']+|"([^"]*)"+|'([^']*)'/gmi)
 

--- a/commands/wiki.js
+++ b/commands/wiki.js
@@ -38,7 +38,7 @@ module.exports = {
       message.react('👎').catch((e) => {
         Util.log(`Wiki Command -> !args[0] -> message.react -> catch e: ${e}`, `${message.guild.name} (${message.guild.id})`, 'err')
       })
-      message.reply('you forgot to search for something. -> \n``' + config.PREFIX + 'wiki [topic] | Example ' + config.PREFIX + 'wiki Rocket League``')
+      message.reply('you forgot to search for something. -> \n``' + config.PREFIX + command + ' [topic] | Example ' + config.PREFIX + 'wiki Rocket League``')
     } else {
       let searchValue = args.toString().replace(/,/g, ' ')
       searchValue = searchValue.replace(config.PREFIX + command + ' ', "")

--- a/commands/wiki.js
+++ b/commands/wiki.js
@@ -7,16 +7,21 @@ const requests = require('./../modules/requests')
  * */
 module.exports = {
   name: 'wiki',
-  alias: ['wiki-de', 'wiki-es'],
+  alias: ['wiki-de', 'wiki-es', 'wiki-fr'],
   description: 'Search something on Wikipedia with this command and get a short summary of it.',
   execute(message, args, config) {
 
     const command = args[0].slice(config.PREFIX.length)
 
     let requestLang = 'en';
-    for(const lang of this.alias){
-      if(command === lang){
-        requestLang = lang.replace('wiki-', '')
+    // Checking if the main command was used.
+    // When not, it will check what language you want to use.
+    // Otherwise, it will just skip the for loop.
+    if(command !== this.name) {
+      for (const lang of this.alias) {
+        if (command === lang) {
+          requestLang = lang.replace('wiki-', '')
+        }
       }
     }
 

--- a/commands/wiki.js
+++ b/commands/wiki.js
@@ -28,10 +28,10 @@ module.exports = {
     // Check in what type of channel the command was executed
     if(message.channel.type === "dm" || message.channel.type === "group"){
       // If it was in a dm or in a group dm, then log only that it was used in a DM channel without logging anything related to the user.
-      Util.log(`${config.PREFIX + this.name} (args: [${args}]) used in a private ${message.channel.type}.`, `Feature: Wiki cmd`)
+      Util.log(`${config.PREFIX + command} (args: [${args}]) used in a private ${message.channel.type}.`, `Feature: Wiki cmd`)
     }else{
       // If it was somewhere else, then log normally like before.
-      Util.log(`${config.PREFIX + this.name} (args: [${args}]) used on ${message.guild.name} (${message.guild.id})`, `Feature: Wiki cmd`)
+      Util.log(`${config.PREFIX + command} (args: [${args}]) used on ${message.guild.name} (${message.guild.id})`, `Feature: Wiki cmd`)
     }
 
     if (!args[1]) {

--- a/commands/wiki.js
+++ b/commands/wiki.js
@@ -7,8 +7,18 @@ const requests = require('./../modules/requests')
  * */
 module.exports = {
   name: 'wiki',
+  alias: ['wiki-de', 'wiki-es'],
   description: 'Search something on Wikipedia with this command and get a short summary of it.',
   execute(message, args, config) {
+
+    const command = args[0].slice(config.PREFIX.length)
+
+    let requestLang = 'en';
+    for(const lang of this.alias){
+      if(command === lang){
+        requestLang = lang.replace('wiki-', '')
+      }
+    }
 
     // Check in what type of channel the command was executed
     if(message.channel.type === "dm" || message.channel.type === "group"){
@@ -23,16 +33,16 @@ module.exports = {
       message.react('👎').catch((e) => {
         Util.log(`Wiki Command -> !args[0] -> message.react -> catch e: ${e}`, `${message.guild.name} (${message.guild.id})`, 'err')
       })
-      message.reply('you forgot to search for something. -> ``' + config.PREFIX + 'wiki [argument] | Example ' + config.PREFIX + 'wiki Rocket League``')
+      message.reply('you forgot to search for something. -> \n``' + config.PREFIX + 'wiki [topic] | Example ' + config.PREFIX + 'wiki Rocket League``')
     } else {
       let searchValue = args.toString().replace(/,/g, ' ')
-      searchValue = searchValue.replace(config.PREFIX + this.name + ' ', "")
+      searchValue = searchValue.replace(config.PREFIX + command + ' ', "")
       // console.log('search value -> ' + searchValue)
       // searchValue = _.startCase(searchValue)
       // console.log('search value -> ' + searchValue)
 
       // console.log('search value: ' + searchValue)
-      requests.getWikipediaShortSummary(message, searchValue)
+      requests.getWikipediaShortSummary(message, searchValue, requestLang)
     }
 
   }

--- a/modules/requests.js
+++ b/modules/requests.js
@@ -40,7 +40,6 @@ exports.getWikipediaShortSummary = (msg, argument, lang) => {
     // Getting the first result of the search results
     // TODO: Find a way to handle disambiguation pages
     let bestResult = data.results[0]
-    console.log(argument)
     // Getting the summary of the first result's page
     wiki({ apiUrl: apiUrl[lang]}).page(bestResult).then(page => {
       page.summary().then(summary => {
@@ -67,7 +66,7 @@ exports.getWikipediaShortSummary = (msg, argument, lang) => {
               timestamp: new Date(),
               footer: {
                 icon_url: 'https://upload.wikimedia.org/wikipedia/commons/6/63/Wikipedia-logo.png',
-                text: 'Information by Wikipedia. wikipedia.org'
+                text: 'Content by Wikipedia - wikipedia.org'
               }
             }
           })

--- a/modules/requests.js
+++ b/modules/requests.js
@@ -13,11 +13,14 @@ const cheerio = require('cheerio')
 const request = require('request')
 const rp = require('request-promise')
 
+// All languages supported by the bot.
+// Before adding any additional API URLs, add an alias for this new language in commands/wiki.js.
 const apiUrl =
   {
     'de' : 'https://de.wikipedia.org/w/api.php',
     'en' : 'https://en.wikipedia.org/w/api.php',
-    'es' : 'https://es.wikipedia.org/w/api.php'
+    'es' : 'https://es.wikipedia.org/w/api.php',
+    'fr' : 'https://fr.wikipedia.org/w/api.php',
   }
 
 var {PREFIX, VERSION, TOKEN, DEVELOPMENT, DISCORDBOTS_TOKEN} = require('./../config')

--- a/modules/requests.js
+++ b/modules/requests.js
@@ -37,6 +37,7 @@ exports.getWikipediaShortSummary = (msg, argument, lang) => {
     // Getting the first result of the search results
     // TODO: Find a way to handle disambiguation pages
     let bestResult = data.results[0]
+    console.log(argument)
     // Getting the summary of the first result's page
     wiki({ apiUrl: apiUrl[lang]}).page(bestResult).then(page => {
       page.summary().then(summary => {

--- a/modules/requests.js
+++ b/modules/requests.js
@@ -13,6 +13,13 @@ const cheerio = require('cheerio')
 const request = require('request')
 const rp = require('request-promise')
 
+const apiUrl =
+  {
+    'de' : 'https://de.wikipedia.org/w/api.php',
+    'en' : 'https://en.wikipedia.org/w/api.php',
+    'es' : 'https://es.wikipedia.org/w/api.php'
+  }
+
 var {PREFIX, VERSION, TOKEN, DEVELOPMENT, DISCORDBOTS_TOKEN} = require('./../config')
 
 /**
@@ -20,17 +27,18 @@ var {PREFIX, VERSION, TOKEN, DEVELOPMENT, DISCORDBOTS_TOKEN} = require('./../con
  *
  * @param {Message} msg - Message class of Discord.js
  * @param {String} argument - Argument sent by the user (!wiki [argument])
+ * @param {String} lang - Language in which the result should be sent.
  *
  * */
-exports.getWikipediaShortSummary = (msg, argument) => {
+exports.getWikipediaShortSummary = (msg, argument, lang) => {
 
   // Searching for the article the user want
-  wiki().search(argument).then(data => {
+  wiki({ apiUrl: apiUrl[lang]}).search(argument).then(data => {
     // Getting the first result of the search results
     // TODO: Find a way to handle disambiguation pages
     let bestResult = data.results[0]
     // Getting the summary of the first result's page
-    wiki().page(bestResult).then(page => {
+    wiki({ apiUrl: apiUrl[lang]}).page(bestResult).then(page => {
       page.summary().then(summary => {
         // Shorten the summary to 768 chars...
         let shortedSummary = summary.split('\n')

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   },
   "homepage": "https://github.com/julianYaman/wikipedia-bot#readme",
   "devDependencies": {
-    "nodemon": "^1.18.10"
+    "nodemon": "^1.19.3"
   },
   "dependencies": {
     "cheerio": "^1.0.0-rc.3",
-    "colors": "^1.3.3",
-    "date-time": "^3.0.0",
+    "colors": "^1.4.0",
+    "date-time": "^3.1.0",
     "dblapi.js": "^2.3.0",
-    "discord.js": "^11.4.2",
+    "discord.js": "^11.5.1",
     "got": "^9.6.0",
     "lodash": "^4.17.11",
     "request": "^2.88.0",


### PR DESCRIPTION
The `wiki`-command now supports more than just the English language. (German, French, Spanish)
A long-requested feature is now included and will be available in the following days.

You can use these command with adding the language prefix to the `wiki`-command.
Example: `!wiki-de` or `!wiki-fr`


- [x] This PR include major improvements. (like a new feature or module)
