### PR TITLE
added Heroku 1 Click deployment support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,5 +64,4 @@ typings/
 .idea
 
 # Project files:
-config.js
 package-lock.json

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+bot: node bot.js

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
     <img src="https://bots.ondiscord.xyz/bots/554751047030013953/embed?theme=dark&showGuilds=true" alt="Wikipedia" />
 </a>
 <a href="https://discordbotlist.com/bots/554751047030013953">
-    <img width="380" height="140" 
-        src="https://discordbotlist.com/bots/554751047030013953/widget" 
+    <img width="380" height="140"
+        src="https://discordbotlist.com/bots/554751047030013953/widget"
         alt="Wikipedia Bot on Discord Bot List">
 </a>
 </p>
@@ -32,7 +32,7 @@
 
 ### Want to give Feedback?
 You can reach me out here:
-- **[E-Mail](mailto:julianyaman@posteo.eu)** - julianyaman@posteo.eu 
+- **[E-Mail](mailto:julianyaman@posteo.eu)** - julianyaman@posteo.eu
 - **[Twitter: @yamanstudios](https://twitter.com/yamanstudios)**
 - **[Discord](https://discord.gg/yAUmDNb)**
 
@@ -58,13 +58,17 @@ In future updates, it will also read articles for you with text-to-speech suppor
 
 ## Contributing
 
-Any type of contribution is welcome. Even reporting problems or suggesting new features 
+Any type of contribution is welcome. Even reporting problems or suggesting new features
 does help a lot to improve the bot.
 
-**If you want to contribute to the codebase of this project, please follow the 
+**If you want to contribute to the codebase of this project, please follow the
 [contributing guidelines](https://github.com/julianYaman/wikipedia-bot/blob/master/docs/CONTRIBUTING.md).**
 
 Also, we recommend to read the [**Code of Conduct**](https://github.com/julianYaman/wikipedia-bot/blob/master/docs/CODE_OF_CONDUCT.md).
+
+## Heroku 1 Click Deployment
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 ## License status
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FjulianYaman%2Fwikipedia-bot.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FjulianYaman%2Fwikipedia-bot?ref=badge_large)

--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "name": "wikipedia-bot",
+  "description": "A Discord bot where you can search articles on Wikipedia and extend your knowledge about the world!",
+  "keywords": [
+    "discord",
+    "bot",
+    "wikipedia"
+  ],
+  "website": "https://www.julianyaman.de/",
+  "env": {
+    "DISCORD_PREFIX": {
+      "description": "Prefix of your Discord bot. !help ^help &help >help",
+      "required": true
+    },
+    "DISCORD_TOKEN": {
+      "description": "The token of your Discord bot application. Get it from here: https://discordapp.com/developers/applications/",
+      "required": true
+    }
+  }
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,8 @@
+// Required: PREFIX, VERSION, TOKEN, DEVELOPMENT
+// Optional: DISCORDBOTS_TOKEN (discordbots.org) , ONDISCORDXYZ_BOTID, ONDISCORDXYZ_TOKEN (both related to bots.ondiscord.xyz), DISCORDBOTLIST_TOKEN
+module.exports = {
+  PREFIX: process.env.DISCORD_PREFIX,
+  VERSION: "1.3",
+  TOKEN: process.env.DISCORD_TOKEN,
+  DEVELOPMENT: false
+}


### PR DESCRIPTION
**Please describe the changes you made:**
Added Heroku 1 click deployment support.  

Advantage:
* Free hosting solution
* no knowledge of git, npm/node required. The user doesn't even see a CLI.

**Type of change:**
Select one or multiple if needed.

- [ ] This PR include bug fixes.
- [ ] This PR include minor improvements. (no big new feature)
- [x] This PR include major improvements. (like a new feature or module)
  - [x] **IF ONE OF THE THREE ABOVE:** The features or fixes made in this PR were tested.
- [ ] This PR include no changes to the code but to other repository files.

Try the Heroku Deployment:
[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://dashboard.heroku.com/new?button-url=https%3A%2F%2Fgithub.com%2Fnntin%2Fwikipedia-bot%2F&template=https%3A%2F%2Fgithub.com%2Fnntin%2Fwikipedia-bot%2F)

I've added similar 1 click deployment to other projects:

https://github.com/nntin/discord-twitter-bot
https://github.com/vegeta897/d-zone (<-- cick the deploy button and only fill out the bot token)
https://github.com/synzen/Discord.RSS

There is an analog video example of how it is working: https://www.youtube.com/watch?v=NwPcXBvStSI  

* go to the README.md and click the Heroku Button.
* fill out the environment variables, hit deploy and wait
* go to the app, switch to resources tab and activate the script (in the video timestamp 2:49)
* wait a little bit, the bot should now come online.

I've tested this deployment on my test server and it is working.