### PR TITLE
Fix 'Too Many Requests' HTTP error caused by multiple API requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const { ShardingManager } = require('discord.js')
 const { TOKEN } = require('./config')
 // Manager
-const manager = new ShardingManager('./bot.js', { token: TOKEN })
+const manager = new ShardingManager('./bot.js', { totalShards: 'auto', token: TOKEN })
 // Logger
 const Util = require('./modules/util')
 const Logger = new Util.Logger()


### PR DESCRIPTION
Since *bot.ondiscord.xyz* only allows one request at the same time and not multiple, HTTP Request errors came up saying that too many requests were made. This was fixed by an unusual but working approach.

This pull request fixes #50

Currently, an error occurs since *bots.ondiscord.xyz* only accepts one request each 2 minutes. With 3 shards, 3 request were made. So now only one shard will make a request to the website. 

This PR also contains another improvement which now also pushes the amount of shards to *top.gg*.

**Type of change:**
Select one or multiple if needed.

- [x] This PR include bug fixes.
- [x] This PR include minor improvements. (no big new feature)
- [ ] This PR include major improvements. (like a new feature or module)
  - [x] **IF ONE OF THE THREE ABOVE:** The features or fixes made in this PR were tested.
- [ ] This PR include no changes to the code but to other repository files.
